### PR TITLE
chore: bump version to 0.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "csp-rspack-plugin",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "A plugin which, when combined with HtmlRspackPlugin, adds CSP tags to the HTML output",
   "main": "plugin.js",
   "types": "plugin.d.ts",


### PR DESCRIPTION
## Summary

- bump the package version from `0.0.2` to `0.0.3`
- prepare the repository for the next package release

## Validation

- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm test` (85 passed, 3 skipped)
